### PR TITLE
resolves #5 output helpful error message when command not found

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,17 @@ export default class Kapok extends EventEmitter {
 			(data) => this.emit('err:data', data),
 		));
 
-		child.on('error', (...args) => this.emit('error', ...args));
+		child.on('error', (...args) => {
+			const err = args[0];
+			if (err && err.code === 'ENOENT') {
+				err.message = 'command not found: "' + command + '"';
+				const spaceIdx = command.indexOf(' ');
+				if (~spaceIdx) {
+					err.message += ' (Did you mean to pass arguments to command `' + command.substr(0, spaceIdx) + '\'?)';
+				}
+			}
+			this.emit('error', ...args);
+		});
 		child.on('exit', (...args) => this.emit('exit', ...args));
 
 		this.child = child;

--- a/test/test.js
+++ b/test/test.js
@@ -249,6 +249,30 @@ test('should throw error if action throws error', async () => {
 	).rejects.toBeDefined();
 });
 
+test('should throw error if command is not found', (done) => {
+	new Kapok('no-such-command')
+	  .on('error', (err) => done())
+	  .done(() => done.fail())
+});
+
+test('should use custom message if command is not found', (done) => {
+	new Kapok('no-such-command')
+	  .on('error', (err) => {
+		expect(err.message).toBe('command not found: "no-such-command"')
+	    done();
+	  })
+	  .done(() => done.fail())
+});
+
+test('should show helpful hint if missing command contains spaces', (done) => {
+	new Kapok('ls -1')
+	  .on('error', (err) => {
+		expect(err.message).toEqual(expect.stringContaining('Did you mean to pass arguments to command `ls\'?'))
+	    done();
+	  })
+	  .done(() => done.fail())
+});
+
 test('should `kill()` work', async () => {
 	const kapok = new Kapok('node', ['-e', 'setTimeout(() => {}, 1000)']);
 	kapok.assert('a');


### PR DESCRIPTION
Kapok now outputs a more helpful error message when a command is not found rather than "spawn ENOENT". If the command contains a space, it adds a hint that the arguments may have been mistakenly bundled with the command name.