### PR TITLE
resolves #10 make kapok-js mocha friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ kapok
 
 - `config.shouldShowLog` \<Boolean\>: Show log message or not. Defaults to `true`
 - `config.shouldThrowError` \<Boolean\>: Throw a new Error or not when assert fails. Defaults to `false`
+- `config.shouldColorizeError` \<Boolean\>: Whether error messages should be colorized using ANSI escape codes. Defaults to `true`
 
 A global config to all `Kapok` instances. Can be override.
 
@@ -165,6 +166,7 @@ The same with `Kapok.start()`
   + `action` \<Function\>: An addition function to do something while `assert` function fires. Support returning a promise for async action
   + `shouldShowLog` \<Boolean\>: Show log message or not. Defaults to `Kapok.config.shouldShowLog`
   + `shouldThrowError` \<Boolean\>: Throw a new Error or not when assert fails. Defaults to `Kapok.config.shouldThrowError`
+  + `shouldColorizeError` \<Boolean\>: Whether ANSI escape codes should be used to colorize error message. Defaults to `Kapok.config.shouldColorizeError`
 - Returns \<Kapok\>
 
 Iterate each line of the process outputs, and assert the data message of each line.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   ],
   "licenses": "MIT",
   "dependencies": {
+    "assertion-error": "^1.1.0",
     "call-me-maybe": "^1.0.1",
     "chalk": "^2.1.0",
     "figures": "^2.0.0",

--- a/test/test.js
+++ b/test/test.js
@@ -221,14 +221,51 @@ test('`assertUntil()`', () => {
 // });
 
 test('should throw error with callback if assert fails', (done) => {
-	const kapok = new Kapok('echo', ['a']);
+	const kapok = new Kapok('echo', ['a\nb']);
 	kapok
 		.assert('b')
+		.assert('c')
 		.done((err) => {
-			expect(err.length).toBe(1);
+			expect(err.length).toBe(2);
 			done();
 		})
 	;
+});
+
+test('should use AssertionError class for assertion errors', (done) => {
+	const input = 'hello world\nget to it';
+	const kapok = new Kapok('echo', [input]);
+	kapok
+		.assert('hallo world')
+		.assert('who there?')
+		.done((err) => {
+			expect(err.length).toBe(2);
+			expect(err[0].constructor.name).toBe('AssertionError');
+			done();
+		})
+	;
+});
+
+test('should not colorize assertion error if shouldColorizeError option is false', (done) => {
+	const input = 'hello world\ngo on';
+	const kapok = new Kapok('echo', [input]);
+	kapok
+		.assert('hallo world', { shouldColorizeError: false })
+		.assert('who there?', { shouldColorizeError: false })
+		.done((err) => {
+			expect(err.length).toBe(2);
+			expect(err[0].message).not.toMatch(/\u001b/);
+			done();
+		})
+	;
+});
+
+test('should unwrap assertion error if errors has length of 1', async () => {
+	const input = 'hello world';
+	const kapok = new Kapok('echo', [input]);
+	await expect(
+		kapok.assert('hallo world').done()
+	).rejects.not.toBeInstanceOf(Array);
 });
 
 test('should throw error with async if assert fails', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -164,6 +164,10 @@ assert-plus@^1.0.0:
   version "1.0.0"
   resolved "http://registry.npm.taobao.org/assert-plus/download/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
 
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+
 async-each@^1.0.0:
   version "1.0.1"
   resolved "http://registry.npm.taobao.org/async-each/download/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"


### PR DESCRIPTION
- use AssertionError class for assertion errors; add assertion-error dependency
- add option to remove colors from error message (shouldColorizeError)
- unwrap error array if it has length of 1
- store actual and expected so that assertion frameworks can show a diff
- add tests
- document shouldColorizeError option in README